### PR TITLE
build: bump go v1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/lvlcn-t/ChronoTemplify
 
-go 1.22
+go 1.23
 
-toolchain go1.22.2
+toolchain go1.23.0
 
 require (
 	github.com/a-h/templ v0.2.747


### PR DESCRIPTION
## Motivation

To bump go to the newest version

## Changes

Bumped the go version to 1.23

For additional information look at the commits.

## Tests done

None

## TODO

- [x] I've assigned this PR to myself
- [x] I've labeled this PR correctly

<!-- Add open ToDo's to this checklist -->